### PR TITLE
Fixed outstanding bugs and made changes to get 'CPANTS clean'

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,11 +1,10 @@
-evision history for Perl module XML::Parser::Lite
+Revision history for Perl module XML::Parser::Lite
 
-0.720_01 2015-05-13 NEILB
+0.721 2015-05-?? PHRED
     - Developer release (with PHRED's permission) to test changes
     - Refactored t/37-mod_xmlrpc.t to make the modules it uses optional,
       using Test::Requires. RT#91434
-    - Specified required versions of XMLRPC::Lite and XMLRPC::Test.
-      GH#4
+    - Specified required versions of XMLRPC::Lite and XMLRPC::Test. GH#4
     - Specified min perl version of 5.006 in Lite.pm and dist metadata
     - Fixed RT#98635 - skip the planned number of tests
     - Changed copyright to refer to XML::Parser::Lite rather than SOAP::Lite
@@ -17,6 +16,9 @@ evision history for Perl module XML::Parser::Lite
       and the SEE ALSO section.
     - Added license type 'perl' to dist metadata, to match the doc.
     - Updated this file (Changes) to follow CPAN::Changes::Spec
+
+0.720_01 2015-05-13 NEILB
+    - Developer release with all the changes subsequently released in 0.721.
 
 0.720 2014-09-15 PHRED
     - RT 96206 - add README

--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ evision history for Perl module XML::Parser::Lite
 
 0.720_01 2015-05-13 NEILB
     - Developer release (with PHRED's permission) to test changes
+    - Refactored t/37-mod_xmlrpc.t to make the modules it uses optional,
+      using Test::Requires. RT#91434
     - Specified min perl version of 5.006 in Lite.pm and dist metadata
     - Fixed RT#98635 - skip the planned number of tests
     - Changed copyright to refer to XML::Parser::Lite rather than SOAP::Lite

--- a/Changes
+++ b/Changes
@@ -11,6 +11,8 @@ evision history for Perl module XML::Parser::Lite
     - Changed copyright to refer to XML::Parser::Lite rather than SOAP::Lite
       (XML::Parser::Lite was forked from SOAP::Lite - see 0.717 below).
       RT#92756
+    - Doc tweaks: improved abstract, first paragraph of DESCRIPTION
+      and the SEE ALSO section.
     - Added license type 'perl' to dist metadata, to match the doc.
     - Updated this file (Changes) to follow CPAN::Changes::Spec
 

--- a/Changes
+++ b/Changes
@@ -4,6 +4,8 @@ evision history for Perl module XML::Parser::Lite
     - Developer release (with PHRED's permission) to test changes
     - Refactored t/37-mod_xmlrpc.t to make the modules it uses optional,
       using Test::Requires. RT#91434
+    - Specified required versions of XMLRPC::Lite and XMLRPC::Test.
+      GH#4
     - Specified min perl version of 5.006 in Lite.pm and dist metadata
     - Fixed RT#98635 - skip the planned number of tests
     - Changed copyright to refer to XML::Parser::Lite rather than SOAP::Lite

--- a/Changes
+++ b/Changes
@@ -1,16 +1,19 @@
-Revision history for Perl extension XML::Parser::Lite.
+Revision history for Perl module XML::Parser::Lite
 
-0.720 Mon Sep 15 2014
+0.721 2015-05-?? PHRED
+    - Updated this file (Changes) to follow CPAN::Changes::Spec
+
+0.720 2014-09-15 PHRED
     - RT 96206 - add README
     - RT 96209 - add links to other parsers
 
-0.719 Mon Dec 2 2013
+0.719 2013-12-02 PHRED
     - RT 90873 - restore test suite
 
-0.718 Tue Nov 26 2013
+0.718 2013-11-26 PHRED
     - add skips for some dependencies
     - https://rt.cpan.org/Ticket/Display.html?id=87604
 
-0.717  Thu May 16 01:18:25 2013
+0.717 2013-05-16 PHRED
 	- forked from SOAP::Lite 0.716
 

--- a/Changes
+++ b/Changes
@@ -4,6 +4,9 @@ evision history for Perl module XML::Parser::Lite
     - Developer release (with PHRED's permission) to test changes
     - Specified min perl version of 5.006 in Lite.pm and dist metadata
     - Fixed RT#98635 - skip the planned number of tests
+    - Changed copyright to refer to XML::Parser::Lite rather than SOAP::Lite
+      (XML::Parser::Lite was forked from SOAP::Lite - see 0.717 below).
+      RT#92756
     - Updated this file (Changes) to follow CPAN::Changes::Spec
 
 0.720 2014-09-15 PHRED

--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Perl module XML::Parser::Lite
 
-0.721 2015-05-?? PHRED
+0.720_01 2015-05-13 NEILB
+    - Developer release (with PHRED's permission) to test changes
+    - Specified min perl version of 5.006 in Lite.pm and dist metadata
     - Updated this file (Changes) to follow CPAN::Changes::Spec
 
 0.720 2014-09-15 PHRED

--- a/Changes
+++ b/Changes
@@ -1,8 +1,9 @@
-Revision history for Perl module XML::Parser::Lite
+evision history for Perl module XML::Parser::Lite
 
 0.720_01 2015-05-13 NEILB
     - Developer release (with PHRED's permission) to test changes
     - Specified min perl version of 5.006 in Lite.pm and dist metadata
+    - Fixed RT#98635 - skip the planned number of tests
     - Updated this file (Changes) to follow CPAN::Changes::Spec
 
 0.720 2014-09-15 PHRED

--- a/Changes
+++ b/Changes
@@ -11,6 +11,7 @@ evision history for Perl module XML::Parser::Lite
     - Changed copyright to refer to XML::Parser::Lite rather than SOAP::Lite
       (XML::Parser::Lite was forked from SOAP::Lite - see 0.717 below).
       RT#92756
+    - Added license type 'perl' to dist metadata, to match the doc.
     - Updated this file (Changes) to follow CPAN::Changes::Spec
 
 0.720 2014-09-15 PHRED

--- a/Changes
+++ b/Changes
@@ -11,6 +11,8 @@ evision history for Perl module XML::Parser::Lite
     - Changed copyright to refer to XML::Parser::Lite rather than SOAP::Lite
       (XML::Parser::Lite was forked from SOAP::Lite - see 0.717 below).
       RT#92756
+    - Set PREREQ_PM, TEST_REQUIRES, and CONFIGURE_REQUIRES depending on
+      whether your version of ExtUtils::MakeMaker supports them.
     - Doc tweaks: improved abstract, first paragraph of DESCRIPTION
       and the SEE ALSO section.
     - Added license type 'perl' to dist metadata, to match the doc.

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use ExtUtils::MakeMaker;
+use ExtUtils::MakeMaker 6.30;
 
 my $mm_ver = $ExtUtils::MakeMaker::VERSION;
 if ($mm_ver =~ /_/) {
@@ -12,10 +12,23 @@ if ($mm_ver =~ /_/) {
     die $@ if $@;
 }
 
+my @REQUIRES = (
+    'strict'    => 0,
+    'warnings'  => 0,
+);
+
+my @TEST_REQUIRES = (
+    'Test::More'        => 0.88,
+    'Test::Requires'    => 0.06,
+    'diagnostics'       => 0,
+);
+
+push(@REQUIRES, @TEST_REQUIRES) if $mm_ver < 6.64;
+
 WriteMakefile(
     NAME          => 'XML::Parser::Lite',
     VERSION_FROM  => 'lib/XML/Parser/Lite.pm',
-    PREREQ_PM     => {},
+    PREREQ_PM     => { @REQUIRES },
     ABSTRACT_FROM => 'lib/XML/Parser/Lite.pm',
     AUTHOR        => 'Byrne Reese (byrne@majordojo.com)',
     META_MERGE    => {
@@ -31,5 +44,17 @@ WriteMakefile(
     ),
 
     ($mm_ver >= 6.31 ? (LICENSE => 'perl') : ()),
+
+    ($mm_ver >= 6.64
+        ? (TEST_REQUIRES => { @TEST_REQUIRES })
+        : ()
+    ),
+
+    ($mm_ver >= 6.52
+        ? (CONFIGURE_REQUIRES => {
+                'ExtUtils::MakeMaker' => 6.30,
+          })
+        : ()
+    ),
 
 );

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -5,6 +5,13 @@ use warnings;
 
 use ExtUtils::MakeMaker;
 
+my $mm_ver = $ExtUtils::MakeMaker::VERSION;
+if ($mm_ver =~ /_/) {
+    # developer release
+    $mm_ver = eval $mm_ver;
+    die $@ if $@;
+}
+
 WriteMakefile(
     NAME          => 'XML::Parser::Lite',
     VERSION_FROM  => 'lib/XML/Parser/Lite.pm',
@@ -17,4 +24,10 @@ WriteMakefile(
               'https://github.com/redhotpenguin/perl-XML-Parser-Lite',
         },
     },
+
+    ($mm_ver >= 6.48
+        ? (MIN_PERL_VERSION => 5.006)
+        : ()
+    ),
+
 );

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -30,4 +30,6 @@ WriteMakefile(
         : ()
     ),
 
+    ($mm_ver >= 6.31 ? (LICENSE => 'perl') : ()),
+
 );

--- a/lib/XML/Parser/Lite.pm
+++ b/lib/XML/Parser/Lite.pm
@@ -12,7 +12,7 @@ package XML::Parser::Lite;
 use strict;
 use warnings;
 
-our $VERSION = 0.720;
+our $VERSION = '0.721';
 
 sub new {
     my $class = shift;

--- a/lib/XML/Parser/Lite.pm
+++ b/lib/XML/Parser/Lite.pm
@@ -9,10 +9,11 @@
 
 package XML::Parser::Lite;
 
+use 5.006;
 use strict;
 use warnings;
 
-our $VERSION = '0.721';
+our $VERSION = '0.720_01';
 
 sub new {
     my $class = shift;

--- a/lib/XML/Parser/Lite.pm
+++ b/lib/XML/Parser/Lite.pm
@@ -13,7 +13,7 @@ use 5.006;
 use strict;
 use warnings;
 
-our $VERSION = '0.720_01';
+our $VERSION = '0.721';
 
 sub new {
     my $class = shift;

--- a/lib/XML/Parser/Lite.pm
+++ b/lib/XML/Parser/Lite.pm
@@ -2,7 +2,7 @@
 #
 # Copyright (C) 2000-2007 Paul Kulchenko (paulclinger@yahoo.com)
 # Copyright (C) 2008 Martin Kutter (martin.kutter@fen-net.de)
-# SOAP::Lite is free software; you can redistribute it
+# XML::Parser::Lite is free software; you can redistribute it
 # and/or modify it under the same terms as Perl itself.
 #
 # ======================================================================
@@ -262,8 +262,10 @@ not re-entrant).
 
 Constructor.
 
-As (almost) all SOAP::Lite constructors, new() returns the object called on
-when called as object method. This means that the following effectively is
+The new() method returns the object called on when called as object method.
+This behaviour was inherited from L<SOAP::Lite>,
+which XML::Parser::Lite was split out from.
+This means that the following effectively is
 a no-op if $obj is a object:
 
  $obj = $obj->new();

--- a/lib/XML/Parser/Lite.pm
+++ b/lib/XML/Parser/Lite.pm
@@ -221,7 +221,7 @@ __END__
 
 =head1 NAME
 
-XML::Parser::Lite - Lightweight regexp-based XML parser
+XML::Parser::Lite - Lightweight pure-perl XML Parser (based on regexps)
 
 =head1 SYNOPSIS
 
@@ -246,8 +246,8 @@ XML::Parser::Lite - Lightweight regexp-based XML parser
 
 =head1 DESCRIPTION
 
-This Perl implements an XML parser with a interface similar to
-XML::Parser. Though not all callbacks are supported, you should be able to
+This module implements an XML parser with a interface similar to
+L<XML::Parser>. Though not all callbacks are supported, you should be able to
 use it in the same way you use XML::Parser. Due to using experimental regexp
 features it'll work only on Perl 5.6 and above and may behave differently on
 different platforms.
@@ -345,13 +345,14 @@ cleanup here.
 
 =head1 SEE ALSO
 
- XML::Parser
+L<XML::Parser> - a full-blown XML Parser, on which XML::Parser::Lite is based.
+Requires a C compiler and the I<expat> XML parser.
 
- XML::Parser::LiteCopy: a fork in XML::Parser::Lite::Tree
+L<XML::Parser::LiteCopy> - a fork in L<XML::Parser::Lite::Tree>.
 
- YAX
+L<YAX> - another pure-perl module for XML parsing.
 
- XML::Parser::REX: the almost original REX code
+L<XML::Parser::REX> - another module that parses XML with regular expressions.
 
 =head1 COPYRIGHT
 
@@ -362,7 +363,8 @@ Copyright (C) 2008- Martin Kutter. All rights reserved.
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself.
 
-This parser is based on "shallow parser" http://www.cs.sfu.ca/~cameron/REX.html
+This parser is based on "shallow parser"
+L<http://www.cs.sfu.ca/~cameron/REX.html>
 Copyright (c) 1998, Robert D. Cameron.
 
 =head1 AUTHOR

--- a/t/26-xmlrpc.t
+++ b/t/26-xmlrpc.t
@@ -25,7 +25,7 @@ SKIP: {
     $r = $s->test_connection;
 
     unless ( defined $r && defined $r->envelope ) {
-        skip 'need XMLRPC::Lite', 8 if $@;
+        skip 'need XMLRPC::Lite', 6 if $@;
         print "1..0 # Skip: ", $s->transport->status, "\n";
         exit;
     }

--- a/t/37-mod_xmlrpc.t
+++ b/t/37-mod_xmlrpc.t
@@ -5,7 +5,10 @@ use warnings;
 
 use Test::More;
 
-use Test::Requires qw/ XMLRPC::Lite XMLRPC::Test /;
+use Test::Requires {
+    'XMLRPC::Lite' => 0.717,
+    'XMLRPC::Test' => 0.717,
+};
 
 XMLRPC::Test::Server::run_for( shift || 'http://localhost/mod_xmlrpc' );
 

--- a/t/37-mod_xmlrpc.t
+++ b/t/37-mod_xmlrpc.t
@@ -5,15 +5,7 @@ use warnings;
 
 use Test::More;
 
-BEGIN { plan tests => 17 }
+use Test::Requires qw/ XMLRPC::Lite XMLRPC::Test /;
 
-eval { require XMLRPC::Lite };
-
-SKIP: {
-
-    skip 'need XMLRPC::Lite', 17 if $@;
-
-    XMLRPC::Test::Server::run_for( shift || 'http://localhost/mod_xmlrpc' );
-
-}
+XMLRPC::Test::Server::run_for( shift || 'http://localhost/mod_xmlrpc' );
 


### PR DESCRIPTION
Hi Fred,

With CPAN Testers back in action, these changes have had only passes so far:

> http://cpantesters.org/distro/X/XML-Parser-Lite.html?grade=1&perlmat=1&patches=2&oncpan=1&distmat=1&perlver=ALL&osname=ALL&version=0.720_01

You should probably check ` t/37-mod_xmlrpc.t` to make sure you're happy with, and that it works as expected.

Cheers,
Neil