### PR TITLE
Add initial AppVeyor configuration

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,13 @@
+cache:
+    - C:\Strawberry -> .appveyor_clear_cache.txt
+
+install:
+  - if not exist "C:\Strawberry" cinst strawberryperl
+  - cinst make
+  - set PATH=C:\strawberry\perl\bin;C:\strawberry\perl\site\bin;C:\strawberry\c\bin;%PATH%
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - cpanm --installdeps . || type C:\Users\appveyor\.cpanm\build.log ; perl -e "exit 1"
+
+build_script:
+  - perl Makefile.PL
+  - make test


### PR DESCRIPTION
[AppVeyor](https://ci.appveyor.com/) is a free continuous integration service for open source projects which allows projects to be built on the Windows platform.  This PR adds an initial configuration file for this service so that the dist can be built and tested on Windows.

If you wish for anything to be changed in this pull request, please don't hesitate to say and I'll update and resubmit as necessary.