### PR TITLE
Purge trailing whitespace

### DIFF
--- a/t/07-xmlrpc_payload.t
+++ b/t/07-xmlrpc_payload.t
@@ -1,4 +1,4 @@
-#!/usr/bin/perl 
+#!/usr/bin/perl
 
 use strict;
 use warnings;

--- a/t/26-xmlrpc.t
+++ b/t/26-xmlrpc.t
@@ -1,4 +1,4 @@
-#!/bin/perl 
+#!/bin/perl
 
 use strict;
 use warnings;

--- a/t/27-xmlparserlite.t
+++ b/t/27-xmlparserlite.t
@@ -1,4 +1,4 @@
-#!/bin/env perl 
+#!/bin/env perl
 
 BEGIN {
     unless(grep /blib/, @INC) {
@@ -12,7 +12,7 @@ use diagnostics;
 use Test;
 
 unless (eval { require XML::Parser::Lite }) {
-    print "1..0 # Skip: ", $@, "\n"; 
+    print "1..0 # Skip: ", $@, "\n";
     exit;
 }
 

--- a/t/37-mod_xmlrpc.t
+++ b/t/37-mod_xmlrpc.t
@@ -1,4 +1,4 @@
-#!/usr/bin/perl 
+#!/usr/bin/perl
 
 use strict;
 use warnings;


### PR DESCRIPTION
Trailing whitespace is seen in some projects as bad practice (e.g. the Linux kernel) and is hence explicitly forbidden; other projects see its removal as plain nit-picking. This PR is submitted in the hope that it is helpful, however if you don't see any need to remove such whitespace I'm happy if you close the PR as unmerged.