### PR TITLE
Move strictures before code

### DIFF
--- a/t/27-xmlparserlite.t
+++ b/t/27-xmlparserlite.t
@@ -1,15 +1,15 @@
 #!/bin/env perl
 
+use strict;
+use diagnostics;
+use Test;
+
 BEGIN {
     unless(grep /blib/, @INC) {
         chdir 't' if -d 't';
         unshift @INC, '../lib' if -d '../lib';
     }
 }
-
-use strict;
-use diagnostics;
-use Test;
 
 unless (eval { require XML::Parser::Lite }) {
     print "1..0 # Skip: ", $@, "\n";


### PR DESCRIPTION
Although in this case this doesn't really change much, it does keep
perlcritic happy.