### PR TITLE
Avoid string eval

### DIFF
--- a/t/26-xmlrpc.t
+++ b/t/26-xmlrpc.t
@@ -65,9 +65,7 @@ SKIP: {
 
     print "XMLRPC autodispatch and fault check test(s)...\n";
 
-    eval "use XMLRPC::Lite +autodispatch =>
-    proxy => '$proxy',
-  ; 1" or die;
+    eval "use XMLRPC::Lite +autodispatch => proxy => '$proxy', ; 1" or die;  ## no critic
 
     $r = XMLRPC->getStateName(21);
 

--- a/t/Lite.t
+++ b/t/Lite.t
@@ -50,7 +50,7 @@ like $@ , qr{ junk \s 'Foobar' \s after \s XML \s element}x, 'detect junk after 
 
 SKIP: {
     skip 'need File::Basename for resolveing filename', 1
-        if ( ! eval "require File::Basename");
+        if ( ! eval { require File::Basename } );
     my $dir = File::Basename::dirname( __FILE__ );
     $parser = XML::Parser::Lite->new();
     open my $fh, '<', "$dir/adam.xml";


### PR DESCRIPTION
This PR avoids string `eval` where possible and tells perlcritic not to stress itself where it's necessary to use a string `eval`.  This change helps the code conform to perlcritic severity level 5.

If you want me to change anything, please just let me know and I'll update and resubmit as necessary.