### PR TITLE
Update link to SOAP::Lite repo in comment

### DIFF
--- a/lib/XML/Parser/Lite.pm
+++ b/lib/XML/Parser/Lite.pm
@@ -64,8 +64,8 @@ sub _regexp {
     # this copyright and citation notice remains intact and that modifications
     # or additions are clearly identified.
 
-    # Modifications may be tracked on SOAP::Lite's SVN at
-    # https://soaplite.svn.sourceforge.net/svnroot/soaplite/
+    # Modifications may be tracked on XML::Parser::Lite's source code repository at
+    # https://github.com/redhotpenguin/perl-XML-Parser-Lite
     #
     use re 'eval';
     my $TextSE = "[^<]+";


### PR DESCRIPTION
I noticed that the link to the `SOAP::Lite` SVN repo no longer exists and updated it to point to the current repo location.

While reading the comments surrounding this code I'm wondering if this particular line might be a leftover from the fork from `SOAP::Lite`.  It looks (to me) like the comment about tracking modifications could actually mean one should point to the `XML::Parser::Lite` repo and not `SOAP::Lite`.  Anyway, let me know which this should be and I'll update the PR appropriately and resubmit if necessary.