### PR TITLE
Update copyright and authors info

### DIFF
--- a/README
+++ b/README
@@ -111,7 +111,9 @@ SEE ALSO
 COPYRIGHT
     Copyright (C) 2000-2007 Paul Kulchenko. All rights reserved.
 
-    Copyright (C) 2008- Martin Kutter. All rights reserved.
+    Copyright (C) 2008 Martin Kutter. All rights reserved.
+
+    Copyright (C) 2013-2015 Fred Moyer. All rights reserved.
 
     This library is free software; you can redistribute it and/or modify it
     under the same terms as Perl itself.

--- a/README
+++ b/README
@@ -122,10 +122,12 @@ COPYRIGHT
     http://www.cs.sfu.ca/~cameron/REX.html Copyright (c) 1998, Robert D.
     Cameron.
 
-AUTHOR
+AUTHORS
     Paul Kulchenko (paulclinger@yahoo.com)
 
     Martin Kutter (martin.kutter@fen-net.de)
+
+    Fred Moyer (fred@redhotpenguin.com)
 
     Additional handlers supplied by Adam Leggett.
 

--- a/lib/XML/Parser/Lite.pm
+++ b/lib/XML/Parser/Lite.pm
@@ -369,11 +369,13 @@ This parser is based on "shallow parser"
 L<http://www.cs.sfu.ca/~cameron/REX.html>
 Copyright (c) 1998, Robert D. Cameron.
 
-=head1 AUTHOR
+=head1 AUTHORS
 
 Paul Kulchenko (paulclinger@yahoo.com)
 
 Martin Kutter (martin.kutter@fen-net.de)
+
+Fred Moyer (fred@redhotpenguin.com)
 
 Additional handlers supplied by Adam Leggett.
 

--- a/lib/XML/Parser/Lite.pm
+++ b/lib/XML/Parser/Lite.pm
@@ -358,7 +358,9 @@ L<XML::Parser::REX> - another module that parses XML with regular expressions.
 
 Copyright (C) 2000-2007 Paul Kulchenko. All rights reserved.
 
-Copyright (C) 2008- Martin Kutter. All rights reserved.
+Copyright (C) 2008 Martin Kutter. All rights reserved.
+
+Copyright (C) 2013-2015 Fred Moyer. All rights reserved.
 
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself.


### PR DESCRIPTION
I noticed that the author and copyright information didn't really match who is currently author of the module.  Hence I've updated things so they match a bit better.  If anything's inaccurate here, please just let me know: I'll be happy to update the PR and resubmit it.