### PR TITLE
Skip unnecessary files in dist

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1,8 +1,9 @@
 Changes
-Makefile.PL
-MANIFEST
-README
 lib/XML/Parser/Lite.pm
+Makefile.PL
+MANIFEST			This list of files
+MANIFEST.SKIP
+README
 t/07-xmlrpc_payload.t
 t/26-xmlrpc.t
 t/27-xmlparserlite.t

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -1,0 +1,14 @@
+.appveyor.yml
+.git/
+.gitignore
+.travis.yml
+^blib/
+^cover_db/
+^Makefile$
+MYMETA.*
+^pm_to_blib
+.*~
+.*\.bak
+.*\.lock
+.*\.old
+.*\.swp


### PR DESCRIPTION
I noticed that there wasn't a `MANIFEST.SKIP` in the repo.  Hopefully this helps in cutting a dist in the future by keeping unwanted files out of the final tarball.