### PR TITLE
Ignore more automatically generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 MYMETA.json
 MYMETA.yml
 Makefile
-blib/
 pm_to_blib
+blib/
+cover_db/
+*.bak
+*.lock
+*.old


### PR DESCRIPTION
For instance those generated by multiple `perl Makefile.PL` runs or from
`Devel::Cover` runs.